### PR TITLE
Add .gitattribute file.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+*.png binary
+*.jpg binary
+*.gif binary
+*.ppm binary
+*.pgm binary
+*.pam binary


### PR DESCRIPTION
This is to prevent checkout on Windows modifying PNM files which have a few text lines.